### PR TITLE
🔒 Fix http → https for external links

### DIFF
--- a/_posts/markdown.md
+++ b/_posts/markdown.md
@@ -89,7 +89,7 @@ export default function Nextra({ Component, pageProps }) {
 
 - [Next.js](https://nextjs.org)
 - [Nextra](https://nextra.vercel.app/)
-- [Vercel](http://vercel.com)
+- [Vercel](https://vercel.com)
 
 ### Footnotes
 


### PR DESCRIPTION
## Change

Fixed insecure http:// link to use https:// instead.

### File Changed
- `_posts/markdown.md`: Updated Vercel link from `http://vercel.com` to `https://vercel.com`

### Why
- All external links should use HTTPS for security and professionalism
- Modern browsers may show warnings for http:// links
- Better SEO signals

---

Small fix, quick merge! 🪸