### PR TITLE
🔒 Fix HTTPS — Site not loading securely

### DIFF
--- a/docs/HTTPS_FIX.md
+++ b/docs/HTTPS_FIX.md
@@ -1,0 +1,58 @@
+# 🔒 HTTPS Configuration Fix
+
+## Current Issues
+
+1. **HTTPS not enforced** — Site loads on `http://` but doesn't redirect to `https://`
+2. **Redirect loop on HTTP** — Causes issues for visitors
+3. **Domain unverified** — Custom domain `eribertolopez.com` shows as unverified
+
+## How to Fix (Manual Steps Required)
+
+### Step 1: Verify Domain on GitHub
+
+1. Go to https://github.com/settings/pages
+2. Click "Add a domain"
+3. Add `eribertolopez.com`
+4. Follow DNS verification steps (add TXT record)
+
+### Step 2: Check DNS Records
+
+Your domain registrar should have these records:
+
+```
+Type    Name    Value
+A       @       185.199.108.153
+A       @       185.199.109.153
+A       @       185.199.110.153
+A       @       185.199.111.153
+AAAA    @       2606:50c0:8000::153
+AAAA    @       2606:50c0:8001::153
+AAAA    @       2606:50c0:8002::153
+AAAA    @       2606:50c0:8003::153
+CNAME   www     eribertolopez.github.io
+```
+
+### Step 3: Enable HTTPS Enforcement
+
+1. Go to https://github.com/EribertoLopez/EribertoLopez.github.io/settings/pages
+2. Scroll to "Custom domain"
+3. Check "Enforce HTTPS" ✓
+
+If the checkbox is grayed out, wait for DNS propagation (can take up to 24 hours).
+
+### Step 4: Verify
+
+After enabling, test:
+- `http://eribertolopez.com` → should redirect to `https://`
+- `https://eribertolopez.com` → should load with valid certificate
+
+## Why This Matters
+
+- 🔒 Security: HTTPS encrypts traffic
+- 📊 SEO: Google ranks HTTPS sites higher
+- 🎨 Professionalism: No browser warnings
+- ⚡ Performance: HTTP/2 requires HTTPS
+
+---
+
+*Created by Coral 🪸 | 2026-02-07*


### PR DESCRIPTION
## The Problem

When I audited **eribertolopez.com**, I found:

| Issue | Status |
|-------|--------|
| `https://eribertolopez.com` | ❌ Fails to load |
| `http://eribertolopez.com` | ❌ Redirect loop |
| HTTPS enforced | ❌ `false` |
| Domain verified | ❌ `unverified` |

This matches the ticket on the board:
> *"Missing HTTPS"* / *"Broken resume page (redirect loop)"*

## Root Cause

GitHub Pages has **"Enforce HTTPS" disabled** and the custom domain is **unverified**.

## The Fix (Requires Manual Steps)

I can't enable this via API — you need to do it in GitHub settings:

### 1. Verify your domain
Go to https://github.com/settings/pages → Add `eribertolopez.com` → Add DNS TXT record

### 2. Enable HTTPS enforcement
Go to https://github.com/EribertoLopez/EribertoLopez.github.io/settings/pages → Check **"Enforce HTTPS"**

See **[docs/HTTPS_FIX.md](docs/HTTPS_FIX.md)** for detailed steps including DNS records.

## After You Fix It

- `http://eribertolopez.com` → redirects to `https://`
- `https://eribertolopez.com` → loads with valid cert
- No more browser warnings
- Better SEO

---

This is the real HTTPS fix — not just changing links in code! 🪸