### PR TITLE
feat: Embeddings — Ollama local / OpenAI production embedding generation

### DIFF
--- a/lib/embeddings.ts
+++ b/lib/embeddings.ts
@@ -1,131 +1,26 @@
-// lib/embeddings.ts
-import OpenAI from "openai";
+// lib/embeddings.ts — Backwards-compatible re-exports
+// New code should import from lib/embeddings/index.ts directly
+import { createEmbeddingProvider } from "./embeddings/index";
+import { cosineSimilarity } from "./utils";
 
-// Configuration - switches between Ollama (local) and OpenAI (production)
-const USE_OPENAI = process.env.EMBEDDING_PROVIDER === "openai";
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
-const OLLAMA_MODEL = process.env.OLLAMA_EMBEDDING_MODEL || "nomic-embed-text";
-const OPENAI_MODEL = process.env.OPENAI_EMBEDDING_MODEL || "text-embedding-3-small";
+export { cosineSimilarity } from "./utils";
+export { createEmbeddingProvider } from "./embeddings/index";
+export type { EmbeddingProvider } from "./embeddings/types";
 
-// OpenAI client (only initialized if using OpenAI)
-const openai = USE_OPENAI
-  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  : null;
+// Backwards-compatible functions using the provider
+const provider = createEmbeddingProvider();
 
-/**
- * Converts text into a vector using Ollama (local).
- */
-async function embedWithOllama(text: string): Promise<number[]> {
-  const response = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: OLLAMA_MODEL,
-      prompt: text,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  return data.embedding;
-}
-
-/**
- * Converts text into a vector using OpenAI (production).
- */
-async function embedWithOpenAI(text: string): Promise<number[]> {
-  if (!openai) throw new Error("OpenAI client not initialized");
-
-  const response = await openai.embeddings.create({
-    model: OPENAI_MODEL,
-    input: text,
-  });
-
-  return response.data[0].embedding;
-}
-
-/**
- * Converts text into a vector (array of numbers).
- *
- * Uses Ollama locally (free, fast) or OpenAI in production (reliable, scalable).
- * Set EMBEDDING_PROVIDER=openai in production.
- *
- * @param text - The text to convert
- * @returns An array of numbers (the embedding vector)
- */
 export async function embedText(text: string): Promise<number[]> {
-  if (USE_OPENAI) {
-    return embedWithOpenAI(text);
-  }
-  return embedWithOllama(text);
+  return provider.embed(text);
 }
 
-/**
- * Get the dimension of embeddings for the current provider.
- * Important: Supabase needs to know the vector dimension!
- */
 export function getEmbeddingDimension(): number {
-  if (USE_OPENAI) {
-    // text-embedding-3-small = 1536 dimensions
-    return 1536;
-  }
-  // nomic-embed-text = 768 dimensions
-  return 768;
+  return provider.dimension;
 }
 
-/**
- * Embeds multiple texts. OpenAI can batch, Ollama goes one at a time.
- *
- * @param texts - Array of texts to embed
- * @param onProgress - Optional callback for progress updates
- */
 export async function embedBatch(
   texts: string[],
   onProgress?: (current: number, total: number) => void
 ): Promise<number[][]> {
-  if (USE_OPENAI && openai) {
-    // OpenAI supports batch embedding
-    const response = await openai.embeddings.create({
-      model: OPENAI_MODEL,
-      input: texts,
-    });
-    return response.data.map((d) => d.embedding);
-  }
-
-  // Ollama: one at a time
-  const embeddings: number[][] = [];
-  for (let i = 0; i < texts.length; i++) {
-    const embedding = await embedWithOllama(texts[i]);
-    embeddings.push(embedding);
-
-    if (onProgress) {
-      onProgress(i + 1, texts.length);
-    }
-  }
-  return embeddings;
-}
-
-/**
- * Calculates how similar two vectors are.
- * Returns a number between -1 and 1, where 1 = identical.
- */
-export function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length !== b.length) {
-    throw new Error("Vectors must have the same length");
-  }
-
-  let dotProduct = 0;
-  let normA = 0;
-  let normB = 0;
-
-  for (let i = 0; i < a.length; i++) {
-    dotProduct += a[i] * b[i];
-    normA += a[i] * a[i];
-    normB += b[i] * b[i];
-  }
-
-  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+  return provider.embedBatch(texts, onProgress);
 }

--- a/lib/embeddings.ts
+++ b/lib/embeddings.ts
@@ -1,0 +1,131 @@
+// lib/embeddings.ts
+import OpenAI from "openai";
+
+// Configuration - switches between Ollama (local) and OpenAI (production)
+const USE_OPENAI = process.env.EMBEDDING_PROVIDER === "openai";
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const OLLAMA_MODEL = process.env.OLLAMA_EMBEDDING_MODEL || "nomic-embed-text";
+const OPENAI_MODEL = process.env.OPENAI_EMBEDDING_MODEL || "text-embedding-3-small";
+
+// OpenAI client (only initialized if using OpenAI)
+const openai = USE_OPENAI
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+/**
+ * Converts text into a vector using Ollama (local).
+ */
+async function embedWithOllama(text: string): Promise<number[]> {
+  const response = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: OLLAMA_MODEL,
+      prompt: text,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.embedding;
+}
+
+/**
+ * Converts text into a vector using OpenAI (production).
+ */
+async function embedWithOpenAI(text: string): Promise<number[]> {
+  if (!openai) throw new Error("OpenAI client not initialized");
+
+  const response = await openai.embeddings.create({
+    model: OPENAI_MODEL,
+    input: text,
+  });
+
+  return response.data[0].embedding;
+}
+
+/**
+ * Converts text into a vector (array of numbers).
+ *
+ * Uses Ollama locally (free, fast) or OpenAI in production (reliable, scalable).
+ * Set EMBEDDING_PROVIDER=openai in production.
+ *
+ * @param text - The text to convert
+ * @returns An array of numbers (the embedding vector)
+ */
+export async function embedText(text: string): Promise<number[]> {
+  if (USE_OPENAI) {
+    return embedWithOpenAI(text);
+  }
+  return embedWithOllama(text);
+}
+
+/**
+ * Get the dimension of embeddings for the current provider.
+ * Important: Supabase needs to know the vector dimension!
+ */
+export function getEmbeddingDimension(): number {
+  if (USE_OPENAI) {
+    // text-embedding-3-small = 1536 dimensions
+    return 1536;
+  }
+  // nomic-embed-text = 768 dimensions
+  return 768;
+}
+
+/**
+ * Embeds multiple texts. OpenAI can batch, Ollama goes one at a time.
+ *
+ * @param texts - Array of texts to embed
+ * @param onProgress - Optional callback for progress updates
+ */
+export async function embedBatch(
+  texts: string[],
+  onProgress?: (current: number, total: number) => void
+): Promise<number[][]> {
+  if (USE_OPENAI && openai) {
+    // OpenAI supports batch embedding
+    const response = await openai.embeddings.create({
+      model: OPENAI_MODEL,
+      input: texts,
+    });
+    return response.data.map((d) => d.embedding);
+  }
+
+  // Ollama: one at a time
+  const embeddings: number[][] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const embedding = await embedWithOllama(texts[i]);
+    embeddings.push(embedding);
+
+    if (onProgress) {
+      onProgress(i + 1, texts.length);
+    }
+  }
+  return embeddings;
+}
+
+/**
+ * Calculates how similar two vectors are.
+ * Returns a number between -1 and 1, where 1 = identical.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error("Vectors must have the same length");
+  }
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/lib/embeddings/index.ts
+++ b/lib/embeddings/index.ts
@@ -1,0 +1,18 @@
+import { pipelineConfig } from "../config";
+import { OllamaEmbedding } from "./ollama";
+import { OpenAIEmbedding } from "./openai";
+import type { EmbeddingProvider } from "./types";
+
+export type { EmbeddingProvider } from "./types";
+
+export function createEmbeddingProvider(): EmbeddingProvider {
+  const { provider, ollama, openai } = pipelineConfig.embedding;
+  switch (provider) {
+    case "openai":
+      return new OpenAIEmbedding(openai.model);
+    case "ollama":
+      return new OllamaEmbedding(ollama.baseUrl, ollama.model);
+    default:
+      throw new Error(`Unknown embedding provider: ${provider}`);
+  }
+}

--- a/lib/embeddings/ollama.ts
+++ b/lib/embeddings/ollama.ts
@@ -1,0 +1,44 @@
+import { EmbeddingError } from "../errors";
+import { withRetry } from "../utils";
+import type { EmbeddingProvider } from "./types";
+
+export class OllamaEmbedding implements EmbeddingProvider {
+  readonly name = "ollama";
+  readonly dimension = 768;
+
+  constructor(
+    private baseUrl = "http://localhost:11434",
+    private model = "nomic-embed-text"
+  ) {}
+
+  async embed(text: string): Promise<number[]> {
+    return withRetry(async () => {
+      const res = await fetch(`${this.baseUrl}/api/embeddings`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: this.model, prompt: text }),
+      });
+      if (!res.ok) {
+        throw new EmbeddingError(`Ollama error: ${res.status} ${res.statusText}`);
+      }
+      const data = await res.json();
+      return data.embedding;
+    });
+  }
+
+  async embedBatch(
+    texts: string[],
+    onProgress?: (current: number, total: number) => void
+  ): Promise<number[][]> {
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i++) {
+      results.push(await this.embed(texts[i]));
+      onProgress?.(i + 1, texts.length);
+      // Rate limit: small delay between calls
+      if (i < texts.length - 1) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+    return results;
+  }
+}

--- a/lib/embeddings/openai.ts
+++ b/lib/embeddings/openai.ts
@@ -1,0 +1,47 @@
+import OpenAI from "openai";
+import { EmbeddingError } from "../errors";
+import { withRetry } from "../utils";
+import type { EmbeddingProvider } from "./types";
+
+export class OpenAIEmbedding implements EmbeddingProvider {
+  readonly name = "openai";
+  readonly dimension = 1536;
+  private client: OpenAI;
+
+  constructor(private model = "text-embedding-3-small") {
+    this.client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+
+  async embed(text: string): Promise<number[]> {
+    return withRetry(async () => {
+      try {
+        const res = await this.client.embeddings.create({
+          model: this.model,
+          input: text,
+        });
+        return res.data[0].embedding;
+      } catch (error) {
+        throw new EmbeddingError(`OpenAI embedding failed`, error);
+      }
+    });
+  }
+
+  async embedBatch(
+    texts: string[],
+    onProgress?: (current: number, total: number) => void
+  ): Promise<number[][]> {
+    return withRetry(async () => {
+      try {
+        const res = await this.client.embeddings.create({
+          model: this.model,
+          input: texts,
+        });
+        const results = res.data.map((d) => d.embedding);
+        onProgress?.(texts.length, texts.length);
+        return results;
+      } catch (error) {
+        throw new EmbeddingError(`OpenAI batch embedding failed`, error);
+      }
+    });
+  }
+}

--- a/lib/embeddings/types.ts
+++ b/lib/embeddings/types.ts
@@ -1,0 +1,11 @@
+// lib/embeddings/types.ts — EmbeddingProvider interface
+
+export interface EmbeddingProvider {
+  readonly name: string;
+  readonly dimension: number;
+  embed(text: string): Promise<number[]>;
+  embedBatch(
+    texts: string[],
+    onProgress?: (current: number, total: number) => void
+  ): Promise<number[][]>;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,42 @@
+// lib/utils.ts — Shared utilities
+
+/**
+ * Retry with exponential backoff.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delayMs = 1000
+): Promise<T> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === retries - 1) throw e;
+      await new Promise((r) => setTimeout(r, delayMs * Math.pow(2, i)));
+    }
+  }
+  throw new Error("unreachable");
+}
+
+/**
+ * Calculates cosine similarity between two vectors.
+ * Returns a number between -1 and 1, where 1 = identical.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error("Vectors must have the same length");
+  }
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
       "dependencies": {
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
+        "dotenv": "^17.2.4",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.461.0",
         "mammoth": "^1.11.0",
         "next": "latest",
+        "openai": "^6.18.0",
         "pdf-parse": "^2.4.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2157,6 +2159,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
+      "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duck": {
@@ -7241,6 +7255,27 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.18.0.tgz",
+      "integrity": "sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/option": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "dependencies": {
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
+    "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.461.0",
     "mammoth": "^1.11.0",
     "next": "latest",
+    "openai": "^6.18.0",
     "pdf-parse": "^2.4.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/scripts/test-embeddings.ts
+++ b/scripts/test-embeddings.ts
@@ -1,0 +1,61 @@
+// scripts/test-embeddings.ts
+import * as dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import {
+  embedText,
+  cosineSimilarity,
+  getEmbeddingDimension,
+} from "../lib/embeddings";
+
+async function main() {
+  const provider =
+    process.env.EMBEDDING_PROVIDER === "openai" ? "OpenAI" : "Ollama";
+  console.log(`🔢 Testing embeddings with ${provider}...\n`);
+
+  // Test 1: Generate an embedding
+  const text1 = "I have 5 years of experience with React and TypeScript";
+  console.log(`Text: "${text1}"`);
+
+  const embedding1 = await embedText(text1);
+  console.log(
+    `Embedding length: ${embedding1.length} dimensions (expected: ${getEmbeddingDimension()})`
+  );
+  console.log(
+    `First 5 values: [${embedding1
+      .slice(0, 5)
+      .map((n) => n.toFixed(4))
+      .join(", ")}...]`
+  );
+  console.log();
+
+  // Test 2: Compare similar texts
+  const text2 = "React and TypeScript development experience";
+  const text3 = "I love cooking Italian food";
+
+  const embedding2 = await embedText(text2);
+  const embedding3 = await embedText(text3);
+
+  const similarity12 = cosineSimilarity(embedding1, embedding2);
+  const similarity13 = cosineSimilarity(embedding1, embedding3);
+
+  console.log("📊 Similarity comparison:");
+  console.log(`"${text1.substring(0, 40)}..." vs`);
+  console.log(
+    `"${text2.substring(0, 40)}..." = ${(similarity12 * 100).toFixed(1)}% similar`
+  );
+  console.log();
+  console.log(`"${text1.substring(0, 40)}..." vs`);
+  console.log(
+    `"${text3.substring(0, 40)}..." = ${(similarity13 * 100).toFixed(1)}% similar`
+  );
+  console.log();
+
+  if (similarity12 > similarity13) {
+    console.log("✅ Embeddings correctly identify similar content!");
+  } else {
+    console.log("❌ Something's wrong with the embeddings");
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## 🔢 Feature 03: Embeddings

**Branch:** `feature/03-embeddings` → `main`
**Depends on:** PR #27 (`feature/02-text-chunking`)
**Part of:** [AI Chat Implementation Plan (#25)](https://github.com/EribertoLopez/EribertoLopez.github.io/pull/25)

### Overview
Convert text chunks into vector embeddings using a hybrid approach: **Ollama for free local development**, **OpenAI for reliable production**. Environment variables control which provider is used.

### Plan

**Files to Create:**
- `lib/embeddings.ts` — `embedText()`, `embedBatch()`, `cosineSimilarity()`, `getEmbeddingDimension()`
- `scripts/test-embeddings.ts` — Verify embeddings work and similar texts score higher

**Architecture:**
- **Local (default):** Ollama with `nomic-embed-text` model (768 dimensions, free)
- **Production:** OpenAI `text-embedding-3-small` (1536 dimensions, paid)
- Switch via `EMBEDDING_PROVIDER=openai` env var

**Key Design:**
- `embedText(text)` → `number[]` — single text embedding
- `embedBatch(texts)` → `number[][]` — batch (OpenAI batches natively, Ollama sequential)
- `cosineSimilarity(a, b)` → `number` — similarity between -1 and 1
- `getEmbeddingDimension()` → 768 or 1536 based on provider

### Prerequisites
```bash
# Local: Install Ollama + pull model
ollama pull nomic-embed-text

# Production: Set OPENAI_API_KEY and EMBEDDING_PROVIDER=openai
```

### Checklist
- [ ] Install `openai` npm package
- [ ] Create `lib/embeddings.ts` with dual-provider support
- [ ] Implement Ollama embedding via HTTP (`/api/embeddings`)
- [ ] Implement OpenAI embedding via SDK
- [ ] Implement `cosineSimilarity()` utility
- [ ] Implement `embedBatch()` with progress callback
- [ ] Create `scripts/test-embeddings.ts`
- [ ] Ollama generates 768-dim embeddings locally
- [ ] OpenAI generates 1536-dim embeddings when configured
- [ ] Similar texts score higher than dissimilar texts
- [ ] Environment variable switches between providers

### Dependencies
- ⬅️ Requires: `feature/02-text-chunking` (#27) — chunks are input
- ➡️ Required by: `feature/04-vector-store` — embeddings stored in DB