### PR TITLE
Phase 2: Chat API — API Gateway + Lambda

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Rate limiting
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX_REQUESTS=10
+
+# ──────────────────────────────────────────────
+# LocalStack / AWS Local Development
+# ──────────────────────────────────────────────
+
+# Set to "true" to route AWS SDK calls to LocalStack
+# USE_LOCALSTACK=true
+# LOCALSTACK_ENDPOINT=http://localhost:4566
+# AWS_REGION=us-east-1
+
+# Local PostgreSQL (used with LocalStack instead of RDS)
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=chatdev
+# DB_PASSWORD=localdev123
+# DB_NAME=portfolio_chat

--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,5 @@ out/
 .DS_Store
 node_modules
 .env.local
+# LocalStack persistent data
+localstack/data/

--- a/docker-compose.localstack.yml
+++ b/docker-compose.localstack.yml
@@ -1,0 +1,54 @@
+# LocalStack Docker Compose for local AWS development
+# Usage: docker compose -f docker-compose.localstack.yml up -d
+# Dashboard: http://localhost:4566/_localstack/health
+#
+# Services emulated: S3, CloudFront (stubbed), Lambda, API Gateway,
+# DynamoDB, SQS, Secrets Manager, SSM, IAM, STS, Bedrock (stubbed)
+
+version: "3.8"
+
+services:
+  localstack:
+    image: localstack/localstack:3.4
+    container_name: localstack-aws-dev
+    ports:
+      - "4566:4566"           # LocalStack Gateway
+      - "4510-4559:4510-4559" # External service ports
+    environment:
+      - SERVICES=s3,lambda,apigateway,apigatewayv2,dynamodb,sqs,secretsmanager,ssm,iam,sts,cloudfront,logs
+      - DEBUG=${LOCALSTACK_DEBUG:-0}
+      - LAMBDA_EXECUTOR=docker-reuse
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_DEFAULT_REGION=us-east-1
+      - PERSISTENCE=1
+    volumes:
+      - "./localstack/init:/etc/localstack/init/ready.d"
+      - "./localstack/data:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # PostgreSQL with pgvector for local vector store (mirrors RDS Phase 6)
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: localstack-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: chatdev
+      POSTGRES_PASSWORD: localdev123
+      POSTGRES_DB: portfolio_chat
+    volumes:
+      - "./localstack/init-db:/docker-entrypoint-initdb.d"
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chatdev"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/docs/LOCAL_DEV_GUIDE.md
+++ b/docs/LOCAL_DEV_GUIDE.md
@@ -1,0 +1,94 @@
+# Local Development Guide — AWS Stack with LocalStack
+
+## Prerequisites
+
+- Docker & Docker Compose
+- Node.js 20+
+- AWS CLI v2 (optional, for `awslocal` wrapper)
+- [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/) (optional but recommended)
+
+## Quick Start
+
+```bash
+# 1. Start LocalStack + PostgreSQL
+./scripts/localstack-setup.sh up
+
+# 2. Set environment
+cp .env.example .env.local
+# Add: USE_LOCALSTACK=true
+
+# 3. Install dependencies
+npm install
+
+# 4. Run the dev server
+npm run dev
+```
+
+## Environment Variables
+
+| Variable | Local Value | Description |
+|----------|------------|-------------|
+| `USE_LOCALSTACK` | `true` | Routes AWS SDK calls to LocalStack |
+| `LOCALSTACK_ENDPOINT` | `http://localhost:4566` | LocalStack endpoint (default) |
+| `AWS_REGION` | `us-east-1` | AWS region |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_USER` | `chatdev` | PostgreSQL user |
+| `DB_PASSWORD` | `localdev123` | PostgreSQL password |
+| `DB_NAME` | `portfolio_chat` | PostgreSQL database |
+
+## What's Running
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| LocalStack | `http://localhost:4566` | S3, Lambda, API Gateway, DynamoDB, SQS, SSM, Secrets Manager |
+| PostgreSQL + pgvector | `localhost:5432` | Vector store (mirrors RDS Phase 6) |
+
+## Using AWS CLI with LocalStack
+
+```bash
+# Option 1: awslocal wrapper (if localstack CLI installed)
+awslocal s3 ls
+awslocal dynamodb list-tables
+
+# Option 2: AWS CLI with --endpoint-url
+aws --endpoint-url=http://localhost:4566 s3 ls
+```
+
+## Testing CDK Stacks Locally
+
+```bash
+cd infra
+USE_LOCALSTACK=true npx cdklocal bootstrap
+USE_LOCALSTACK=true npx cdklocal deploy --all
+```
+
+## Services Setup
+
+The init script (`localstack/init/01-setup-resources.sh`) automatically creates:
+- S3 bucket: `eribertolopez-site`
+- SSM parameters: `/chat-api/url`, `/chat-api/allowed-origins`
+- Secrets Manager: `portfolio-chat/db-credentials`
+- DynamoDB table: `chat-rate-limits`
+- SQS queue: `ingestion-queue`
+
+PostgreSQL init (`localstack/init-db/01-init-pgvector.sql`) creates:
+- `vector` extension
+- `documents` table with embedding column
+- HNSW index for similarity search
+
+## Lifecycle
+
+```bash
+./scripts/localstack-setup.sh up      # Start
+./scripts/localstack-setup.sh status   # Check health
+./scripts/localstack-setup.sh logs     # View logs
+./scripts/localstack-setup.sh down     # Stop (preserves data)
+./scripts/localstack-setup.sh clean    # Stop + delete all data
+```
+
+## Limitations
+
+- **Bedrock is not emulated** — LocalStack community edition doesn't support Bedrock. For local chat/embedding testing, use Ollama providers (already configured in `lib/embeddings/ollama.ts` and `lib/chat/ollama.ts`).
+- **CloudFront** — Stubbed only. Test S3 serving directly.
+- **Lambda** — Requires Docker-in-Docker. Works with `LAMBDA_EXECUTOR=docker-reuse`.

--- a/infra/lib/chat-api-stack.ts
+++ b/infra/lib/chat-api-stack.ts
@@ -1,14 +1,10 @@
-// TODO: Phase 2 - Chat API Stack
-// Creates:
-// - Lambda function (Node.js 20, bundled from lambda/)
-// - HTTP API Gateway with CORS
-// - Lambda IAM role with Bedrock invoke permissions
-// - CloudWatch log group
-// - Environment variables: SUPABASE_URL, model IDs
-//
-// See docs/AWS_MIGRATION_PLAN.md "Phase 2" for full details.
+// Phase 2: Chat API Stack
+// Lambda + HTTP API Gateway + IAM + Throttling
+// See docs/AWS_MIGRATION_PLAN.md "Phase 2"
 
 import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
 export interface ChatApiStackProps extends cdk.StackProps {
@@ -21,13 +17,37 @@ export class ChatApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ChatApiStackProps) {
     super(scope, id, props);
 
-    // TODO: Create Lambda function from lambda/ directory
-    // TODO: Add Bedrock IAM permissions (bedrock:InvokeModel, bedrock:InvokeModelWithResponseStream)
-    // TODO: Create HTTP API Gateway with CORS config
-    // TODO: Add routes: POST /chat, GET /health
-    // TODO: Configure Lambda environment variables
-    // TODO: Output API URL
+    // Lambda execution role — least-privilege Bedrock access
+    const lambdaRole = new iam.Role(this, "ChatLambdaRole", {
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+      ],
+    });
 
-    this.apiUrl = ""; // TODO: Set from API Gateway
+    // Bedrock permissions — scoped to specific models
+    lambdaRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+        resources: [
+          `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-haiku-20240307-v1:0`,
+          `arn:aws:bedrock:${this.region}::foundation-model/amazon.titan-embed-text-v2:0`,
+        ],
+      })
+    );
+
+    // TODO: Create Lambda function from lambda/ directory
+    //   - Runtime: Node.js 20
+    //   - Memory: 512MB (Bedrock client needs it)
+    //   - Timeout: 60s (streaming chat responses)
+    //   - Environment: ALLOWED_ORIGINS, BEDROCK_CHAT_MODEL_ID, BEDROCK_EMBED_MODEL_ID
+
+    // TODO: Create HTTP API Gateway with:
+    //   - CORS restricted to allowedOrigins (not wildcard *)
+    //   - Throttling: 100 burst, 50 sustained requests/second
+    //   - Routes: POST /chat, GET /health
+
+    // TODO: Output API URL
+    this.apiUrl = ""; // Set from API Gateway
   }
 }

--- a/infra/lib/chat-api-stack.ts
+++ b/infra/lib/chat-api-stack.ts
@@ -1,0 +1,33 @@
+// TODO: Phase 2 - Chat API Stack
+// Creates:
+// - Lambda function (Node.js 20, bundled from lambda/)
+// - HTTP API Gateway with CORS
+// - Lambda IAM role with Bedrock invoke permissions
+// - CloudWatch log group
+// - Environment variables: SUPABASE_URL, model IDs
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 2" for full details.
+
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export interface ChatApiStackProps extends cdk.StackProps {
+  allowedOrigins: string[];
+}
+
+export class ChatApiStack extends cdk.Stack {
+  public readonly apiUrl: string;
+
+  constructor(scope: Construct, id: string, props: ChatApiStackProps) {
+    super(scope, id, props);
+
+    // TODO: Create Lambda function from lambda/ directory
+    // TODO: Add Bedrock IAM permissions (bedrock:InvokeModel, bedrock:InvokeModelWithResponseStream)
+    // TODO: Create HTTP API Gateway with CORS config
+    // TODO: Add routes: POST /chat, GET /health
+    // TODO: Configure Lambda environment variables
+    // TODO: Output API URL
+
+    this.apiUrl = ""; // TODO: Set from API Gateway
+  }
+}

--- a/lambda/handler.ts
+++ b/lambda/handler.ts
@@ -1,32 +1,88 @@
-// TODO: Phase 2 - Chat API Lambda Handler
-// This Lambda function handles POST /chat requests:
-// 1. Parse user message from request body
-// 2. Generate embedding via Bedrock Titan (Phase 3)
-// 3. Search vector store for relevant context
-// 4. Call Bedrock Claude with context + user message
-// 5. Stream response back via API Gateway
-//
-// See docs/AWS_MIGRATION_PLAN.md "Phase 2" for details.
+// Phase 2: Chat API Lambda Handler
+// Handles POST /chat and GET /health
+// See docs/AWS_MIGRATION_PLAN.md "Phase 2"
 
 import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
 
-export async function handler(
-  event: APIGatewayProxyEventV2
-): Promise<APIGatewayProxyResultV2> {
-  // TODO: Parse request body { message: string, history?: Message[] }
-  // TODO: Validate input (max length, rate limiting)
-  // TODO: Generate embedding for the query
-  // TODO: Search vector store for top-k relevant chunks
-  // TODO: Build prompt with system message + context + history
-  // TODO: Call Bedrock Claude (streaming)
-  // TODO: Return streaming response
+// --- Types ---
+interface ChatRequest {
+  message: string;
+  history?: Array<{ role: "user" | "assistant"; content: string }>;
+}
 
-  if (event.routeKey === "GET /health") {
-    return { statusCode: 200, body: JSON.stringify({ status: "ok" }) };
-  }
+interface ErrorResponse {
+  error: string;
+  code: string;
+}
 
+// --- Constants ---
+const MAX_MESSAGE_LENGTH = 4000;
+const MAX_HISTORY_LENGTH = 20;
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ?? "").split(",").filter(Boolean);
+
+// --- Helpers ---
+function corsHeaders(origin?: string): Record<string, string> {
+  const allowedOrigin = origin && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] ?? "";
   return {
-    statusCode: 501,
-    body: JSON.stringify({ error: "Not implemented" }),
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Content-Type": "application/json",
   };
+}
+
+function errorResponse(statusCode: number, code: string, message: string, origin?: string): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: corsHeaders(origin),
+    body: JSON.stringify({ error: message, code } satisfies ErrorResponse),
+  };
+}
+
+function validateRequest(body: unknown): ChatRequest {
+  if (!body || typeof body !== "object") throw new Error("INVALID_BODY");
+  const req = body as Record<string, unknown>;
+  if (typeof req.message !== "string" || req.message.trim().length === 0) throw new Error("EMPTY_MESSAGE");
+  if (req.message.length > MAX_MESSAGE_LENGTH) throw new Error("MESSAGE_TOO_LONG");
+  if (req.history && (!Array.isArray(req.history) || req.history.length > MAX_HISTORY_LENGTH)) {
+    throw new Error("INVALID_HISTORY");
+  }
+  return { message: req.message.trim(), history: (req.history as ChatRequest["history"]) ?? [] };
+}
+
+// --- Handler ---
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
+  const origin = event.headers?.origin;
+
+  try {
+    // Health check
+    if (event.routeKey === "GET /health") {
+      return { statusCode: 200, headers: corsHeaders(origin), body: JSON.stringify({ status: "ok" }) };
+    }
+
+    // Chat endpoint
+    if (event.routeKey === "POST /chat") {
+      const parsed = JSON.parse(event.body ?? "{}");
+      const request = validateRequest(parsed);
+
+      // TODO: Generate embedding for request.message (Phase 3 - Bedrock Titan)
+      // TODO: Search vector store for relevant context
+      // TODO: Build prompt with system message + context + history
+      // TODO: Call Bedrock Claude with streaming (Phase 3)
+      // TODO: Return streaming response using awslambda.streamifyResponse
+
+      return errorResponse(501, "NOT_IMPLEMENTED", "Chat not yet implemented", origin);
+    }
+
+    return errorResponse(404, "NOT_FOUND", "Route not found", origin);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal server error";
+    console.error("Handler error:", err);
+
+    if (["INVALID_BODY", "EMPTY_MESSAGE", "MESSAGE_TOO_LONG", "INVALID_HISTORY"].includes(message)) {
+      return errorResponse(400, message, message, origin);
+    }
+
+    return errorResponse(500, "INTERNAL_ERROR", "Internal server error", origin);
+  }
 }

--- a/lambda/handler.ts
+++ b/lambda/handler.ts
@@ -1,0 +1,32 @@
+// TODO: Phase 2 - Chat API Lambda Handler
+// This Lambda function handles POST /chat requests:
+// 1. Parse user message from request body
+// 2. Generate embedding via Bedrock Titan (Phase 3)
+// 3. Search vector store for relevant context
+// 4. Call Bedrock Claude with context + user message
+// 5. Stream response back via API Gateway
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 2" for details.
+
+import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
+
+export async function handler(
+  event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> {
+  // TODO: Parse request body { message: string, history?: Message[] }
+  // TODO: Validate input (max length, rate limiting)
+  // TODO: Generate embedding for the query
+  // TODO: Search vector store for top-k relevant chunks
+  // TODO: Build prompt with system message + context + history
+  // TODO: Call Bedrock Claude (streaming)
+  // TODO: Return streaming response
+
+  if (event.routeKey === "GET /health") {
+    return { statusCode: 200, body: JSON.stringify({ status: "ok" }) };
+  }
+
+  return {
+    statusCode: 501,
+    body: JSON.stringify({ error: "Not implemented" }),
+  };
+}

--- a/lib/aws-config.ts
+++ b/lib/aws-config.ts
@@ -1,0 +1,68 @@
+// AWS SDK configuration with LocalStack support
+// Set USE_LOCALSTACK=true to route all AWS calls to LocalStack
+//
+// Usage:
+//   import { getAwsConfig, getEndpoint } from "@/lib/aws-config";
+//   const client = new S3Client(getAwsConfig());
+
+export interface AwsConfig {
+  region: string;
+  endpoint?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+  forcePathStyle?: boolean; // For S3 with LocalStack
+}
+
+const LOCALSTACK_ENDPOINT =
+  process.env.LOCALSTACK_ENDPOINT ?? "http://localhost:4566";
+
+export function isLocalStack(): boolean {
+  return process.env.USE_LOCALSTACK === "true";
+}
+
+export function getEndpoint(): string | undefined {
+  return isLocalStack() ? LOCALSTACK_ENDPOINT : undefined;
+}
+
+export function getAwsConfig(): AwsConfig {
+  const config: AwsConfig = {
+    region: process.env.AWS_REGION ?? "us-east-1",
+  };
+
+  if (isLocalStack()) {
+    config.endpoint = LOCALSTACK_ENDPOINT;
+    config.credentials = {
+      accessKeyId: "test",
+      secretAccessKey: "test",
+    };
+    config.forcePathStyle = true; // Required for S3 with LocalStack
+  }
+
+  return config;
+}
+
+// Database config — uses Secrets Manager in prod, env vars with LocalStack
+export function getDbConfig() {
+  if (isLocalStack()) {
+    return {
+      host: process.env.DB_HOST ?? "localhost",
+      port: parseInt(process.env.DB_PORT ?? "5432"),
+      user: process.env.DB_USER ?? "chatdev",
+      password: process.env.DB_PASSWORD ?? "localdev123",
+      database: process.env.DB_NAME ?? "portfolio_chat",
+      ssl: false,
+    };
+  }
+
+  // Production: credentials come from Secrets Manager via RDS Proxy IAM auth
+  return {
+    host: process.env.DB_HOST!,
+    port: parseInt(process.env.DB_PORT ?? "5432"),
+    user: process.env.DB_USER!,
+    database: process.env.DB_NAME ?? "portfolio_chat",
+    ssl: { rejectUnauthorized: true },
+    // IAM auth token is generated at connection time
+  };
+}

--- a/localstack/init-db/01-init-pgvector.sql
+++ b/localstack/init-db/01-init-pgvector.sql
@@ -1,0 +1,22 @@
+-- Initialize pgvector extension and schema for local development
+-- Mirrors Phase 6 RDS PostgreSQL setup
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS documents (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  embedding vector(1024),  -- Titan v2 dimensions
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- HNSW index for fast cosine similarity search
+CREATE INDEX IF NOT EXISTS documents_embedding_idx
+  ON documents USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Index for metadata filtering
+CREATE INDEX IF NOT EXISTS documents_metadata_idx
+  ON documents USING gin (metadata);

--- a/localstack/init/01-setup-resources.sh
+++ b/localstack/init/01-setup-resources.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# LocalStack init script — runs when LocalStack is ready
+# Creates AWS resources that mirror production infrastructure
+
+set -euo pipefail
+
+ENDPOINT="http://localhost:4566"
+REGION="us-east-1"
+AWS="awslocal"
+
+echo "==> Creating S3 bucket (mirrors Phase 1 StaticSiteStack)..."
+$AWS s3 mb s3://eribertolopez-site --region $REGION 2>/dev/null || true
+$AWS s3api put-bucket-encryption --bucket eribertolopez-site \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+echo "==> Creating SSM parameters..."
+$AWS ssm put-parameter --name /chat-api/url --value "http://localhost:4566/restapis" --type String --overwrite
+$AWS ssm put-parameter --name /chat-api/allowed-origins --value "http://localhost:3000,http://localhost:4566" --type String --overwrite
+
+echo "==> Creating Secrets Manager secret (mirrors Phase 6 RDS credentials)..."
+$AWS secretsmanager create-secret \
+  --name portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}' \
+  2>/dev/null || \
+$AWS secretsmanager update-secret \
+  --secret-id portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}'
+
+echo "==> Creating DynamoDB table for rate limiting..."
+$AWS dynamodb create-table \
+  --table-name chat-rate-limits \
+  --attribute-definitions AttributeName=pk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region $REGION 2>/dev/null || true
+
+echo "==> Creating SQS queue for ingestion..."
+$AWS sqs create-queue --queue-name ingestion-queue --region $REGION 2>/dev/null || true
+
+echo "==> LocalStack initialization complete!"

--- a/scripts/localstack-setup.sh
+++ b/scripts/localstack-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Quick setup script for LocalStack local development
+# Usage: ./scripts/localstack-setup.sh [up|down|status|logs]
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.localstack.yml"
+ACTION="${1:-up}"
+
+case "$ACTION" in
+  up)
+    echo "🚀 Starting LocalStack + PostgreSQL..."
+    docker compose -f "$COMPOSE_FILE" up -d
+    echo ""
+    echo "⏳ Waiting for services to be healthy..."
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    echo "✅ LocalStack: http://localhost:4566/_localstack/health"
+    echo "✅ PostgreSQL: localhost:5432 (chatdev/localdev123)"
+    echo ""
+    echo "Set these environment variables:"
+    echo "  export USE_LOCALSTACK=true"
+    echo "  export AWS_DEFAULT_REGION=us-east-1"
+    echo ""
+    echo "Or add to .env.local:"
+    echo "  USE_LOCALSTACK=true"
+    ;;
+  down)
+    echo "🛑 Stopping LocalStack..."
+    docker compose -f "$COMPOSE_FILE" down
+    ;;
+  clean)
+    echo "🧹 Stopping and removing all data..."
+    docker compose -f "$COMPOSE_FILE" down -v
+    rm -rf localstack/data
+    ;;
+  status)
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    curl -s http://localhost:4566/_localstack/health | python3 -m json.tool 2>/dev/null || echo "LocalStack not running"
+    ;;
+  logs)
+    docker compose -f "$COMPOSE_FILE" logs -f "${2:-localstack}"
+    ;;
+  *)
+    echo "Usage: $0 [up|down|clean|status|logs]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Phase 2: Chat API

Implements stubs for Phase 2 of the [AWS Migration Plan](docs/AWS_MIGRATION_PLAN.md).

### What's included
- `lambda/handler.ts` — Lambda handler stub with health check route
- `infra/lib/chat-api-stack.ts` — CDK stack placeholder

### What needs implementation
- Lambda function bundling and deployment
- HTTP API Gateway with CORS
- Bedrock IAM permissions
- Request validation and rate limiting
- Streaming response support

Depends on: Phase 1 (#TBD)