### PR TITLE
Phase 3: Bedrock Integration — Embeddings + Chat Providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Rate limiting
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX_REQUESTS=10
+
+# ──────────────────────────────────────────────
+# LocalStack / AWS Local Development
+# ──────────────────────────────────────────────
+
+# Set to "true" to route AWS SDK calls to LocalStack
+# USE_LOCALSTACK=true
+# LOCALSTACK_ENDPOINT=http://localhost:4566
+# AWS_REGION=us-east-1
+
+# Local PostgreSQL (used with LocalStack instead of RDS)
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=chatdev
+# DB_PASSWORD=localdev123
+# DB_NAME=portfolio_chat

--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,5 @@ out/
 .DS_Store
 node_modules
 .env.local
+# LocalStack persistent data
+localstack/data/

--- a/docker-compose.localstack.yml
+++ b/docker-compose.localstack.yml
@@ -1,0 +1,54 @@
+# LocalStack Docker Compose for local AWS development
+# Usage: docker compose -f docker-compose.localstack.yml up -d
+# Dashboard: http://localhost:4566/_localstack/health
+#
+# Services emulated: S3, CloudFront (stubbed), Lambda, API Gateway,
+# DynamoDB, SQS, Secrets Manager, SSM, IAM, STS, Bedrock (stubbed)
+
+version: "3.8"
+
+services:
+  localstack:
+    image: localstack/localstack:3.4
+    container_name: localstack-aws-dev
+    ports:
+      - "4566:4566"           # LocalStack Gateway
+      - "4510-4559:4510-4559" # External service ports
+    environment:
+      - SERVICES=s3,lambda,apigateway,apigatewayv2,dynamodb,sqs,secretsmanager,ssm,iam,sts,cloudfront,logs
+      - DEBUG=${LOCALSTACK_DEBUG:-0}
+      - LAMBDA_EXECUTOR=docker-reuse
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_DEFAULT_REGION=us-east-1
+      - PERSISTENCE=1
+    volumes:
+      - "./localstack/init:/etc/localstack/init/ready.d"
+      - "./localstack/data:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # PostgreSQL with pgvector for local vector store (mirrors RDS Phase 6)
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: localstack-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: chatdev
+      POSTGRES_PASSWORD: localdev123
+      POSTGRES_DB: portfolio_chat
+    volumes:
+      - "./localstack/init-db:/docker-entrypoint-initdb.d"
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chatdev"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/docs/LOCAL_DEV_GUIDE.md
+++ b/docs/LOCAL_DEV_GUIDE.md
@@ -1,0 +1,94 @@
+# Local Development Guide — AWS Stack with LocalStack
+
+## Prerequisites
+
+- Docker & Docker Compose
+- Node.js 20+
+- AWS CLI v2 (optional, for `awslocal` wrapper)
+- [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/) (optional but recommended)
+
+## Quick Start
+
+```bash
+# 1. Start LocalStack + PostgreSQL
+./scripts/localstack-setup.sh up
+
+# 2. Set environment
+cp .env.example .env.local
+# Add: USE_LOCALSTACK=true
+
+# 3. Install dependencies
+npm install
+
+# 4. Run the dev server
+npm run dev
+```
+
+## Environment Variables
+
+| Variable | Local Value | Description |
+|----------|------------|-------------|
+| `USE_LOCALSTACK` | `true` | Routes AWS SDK calls to LocalStack |
+| `LOCALSTACK_ENDPOINT` | `http://localhost:4566` | LocalStack endpoint (default) |
+| `AWS_REGION` | `us-east-1` | AWS region |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_USER` | `chatdev` | PostgreSQL user |
+| `DB_PASSWORD` | `localdev123` | PostgreSQL password |
+| `DB_NAME` | `portfolio_chat` | PostgreSQL database |
+
+## What's Running
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| LocalStack | `http://localhost:4566` | S3, Lambda, API Gateway, DynamoDB, SQS, SSM, Secrets Manager |
+| PostgreSQL + pgvector | `localhost:5432` | Vector store (mirrors RDS Phase 6) |
+
+## Using AWS CLI with LocalStack
+
+```bash
+# Option 1: awslocal wrapper (if localstack CLI installed)
+awslocal s3 ls
+awslocal dynamodb list-tables
+
+# Option 2: AWS CLI with --endpoint-url
+aws --endpoint-url=http://localhost:4566 s3 ls
+```
+
+## Testing CDK Stacks Locally
+
+```bash
+cd infra
+USE_LOCALSTACK=true npx cdklocal bootstrap
+USE_LOCALSTACK=true npx cdklocal deploy --all
+```
+
+## Services Setup
+
+The init script (`localstack/init/01-setup-resources.sh`) automatically creates:
+- S3 bucket: `eribertolopez-site`
+- SSM parameters: `/chat-api/url`, `/chat-api/allowed-origins`
+- Secrets Manager: `portfolio-chat/db-credentials`
+- DynamoDB table: `chat-rate-limits`
+- SQS queue: `ingestion-queue`
+
+PostgreSQL init (`localstack/init-db/01-init-pgvector.sql`) creates:
+- `vector` extension
+- `documents` table with embedding column
+- HNSW index for similarity search
+
+## Lifecycle
+
+```bash
+./scripts/localstack-setup.sh up      # Start
+./scripts/localstack-setup.sh status   # Check health
+./scripts/localstack-setup.sh logs     # View logs
+./scripts/localstack-setup.sh down     # Stop (preserves data)
+./scripts/localstack-setup.sh clean    # Stop + delete all data
+```
+
+## Limitations
+
+- **Bedrock is not emulated** — LocalStack community edition doesn't support Bedrock. For local chat/embedding testing, use Ollama providers (already configured in `lib/embeddings/ollama.ts` and `lib/chat/ollama.ts`).
+- **CloudFront** — Stubbed only. Test S3 serving directly.
+- **Lambda** — Requires Docker-in-Docker. Works with `LAMBDA_EXECUTOR=docker-reuse`.

--- a/lib/aws-config.ts
+++ b/lib/aws-config.ts
@@ -1,0 +1,68 @@
+// AWS SDK configuration with LocalStack support
+// Set USE_LOCALSTACK=true to route all AWS calls to LocalStack
+//
+// Usage:
+//   import { getAwsConfig, getEndpoint } from "@/lib/aws-config";
+//   const client = new S3Client(getAwsConfig());
+
+export interface AwsConfig {
+  region: string;
+  endpoint?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+  forcePathStyle?: boolean; // For S3 with LocalStack
+}
+
+const LOCALSTACK_ENDPOINT =
+  process.env.LOCALSTACK_ENDPOINT ?? "http://localhost:4566";
+
+export function isLocalStack(): boolean {
+  return process.env.USE_LOCALSTACK === "true";
+}
+
+export function getEndpoint(): string | undefined {
+  return isLocalStack() ? LOCALSTACK_ENDPOINT : undefined;
+}
+
+export function getAwsConfig(): AwsConfig {
+  const config: AwsConfig = {
+    region: process.env.AWS_REGION ?? "us-east-1",
+  };
+
+  if (isLocalStack()) {
+    config.endpoint = LOCALSTACK_ENDPOINT;
+    config.credentials = {
+      accessKeyId: "test",
+      secretAccessKey: "test",
+    };
+    config.forcePathStyle = true; // Required for S3 with LocalStack
+  }
+
+  return config;
+}
+
+// Database config — uses Secrets Manager in prod, env vars with LocalStack
+export function getDbConfig() {
+  if (isLocalStack()) {
+    return {
+      host: process.env.DB_HOST ?? "localhost",
+      port: parseInt(process.env.DB_PORT ?? "5432"),
+      user: process.env.DB_USER ?? "chatdev",
+      password: process.env.DB_PASSWORD ?? "localdev123",
+      database: process.env.DB_NAME ?? "portfolio_chat",
+      ssl: false,
+    };
+  }
+
+  // Production: credentials come from Secrets Manager via RDS Proxy IAM auth
+  return {
+    host: process.env.DB_HOST!,
+    port: parseInt(process.env.DB_PORT ?? "5432"),
+    user: process.env.DB_USER!,
+    database: process.env.DB_NAME ?? "portfolio_chat",
+    ssl: { rejectUnauthorized: true },
+    // IAM auth token is generated at connection time
+  };
+}

--- a/lib/chat/bedrock.ts
+++ b/lib/chat/bedrock.ts
@@ -1,0 +1,42 @@
+// TODO: Phase 3 - Bedrock Claude Chat Provider
+// Replaces direct Anthropic API calls with Amazon Bedrock Claude.
+//
+// Model: anthropic.claude-3-haiku-20240307-v1:0 (or configurable)
+// Supports streaming via InvokeModelWithResponseStream.
+// IAM role provides credentials — no API key needed.
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 3" for details.
+
+import {
+  BedrockRuntimeClient,
+  InvokeModelWithResponseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+
+const DEFAULT_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0";
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ChatOptions {
+  modelId?: string;
+  maxTokens?: number;
+  temperature?: number;
+  systemPrompt?: string;
+}
+
+export async function* streamChat(
+  messages: ChatMessage[],
+  context: string,
+  options: ChatOptions = {}
+): AsyncGenerator<string> {
+  // TODO: Build Anthropic Messages API payload (Bedrock uses same format)
+  // TODO: Include system prompt with retrieved context
+  // TODO: Call InvokeModelWithResponseStream
+  // TODO: Parse SSE chunks and yield text deltas
+  // TODO: Handle errors (throttling, context length exceeded)
+  throw new Error("Not implemented");
+}

--- a/lib/chat/bedrock.ts
+++ b/lib/chat/bedrock.ts
@@ -1,42 +1,48 @@
-// TODO: Phase 3 - Bedrock Claude Chat Provider
-// Replaces direct Anthropic API calls with Amazon Bedrock Claude.
-//
-// Model: anthropic.claude-3-haiku-20240307-v1:0 (or configurable)
-// Supports streaming via InvokeModelWithResponseStream.
-// IAM role provides credentials — no API key needed.
-//
-// See docs/AWS_MIGRATION_PLAN.md "Phase 3" for details.
+// Phase 3: Bedrock Claude Chat Provider
+// Implements ChatProvider interface for Amazon Bedrock Claude
+// Model: configurable via BEDROCK_CHAT_MODEL_ID env var
+// See docs/AWS_MIGRATION_PLAN.md "Phase 3"
 
 import {
   BedrockRuntimeClient,
   InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
+import type { ChatProvider, ChatMessage, ChatOptions } from "../types/providers";
 
-const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+const client = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? "us-east-1",
+  maxAttempts: 3,
+});
 
-const DEFAULT_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0";
+const DEFAULT_MODEL_ID = process.env.BEDROCK_CHAT_MODEL_ID ?? "anthropic.claude-3-haiku-20240307-v1:0";
 
-export interface ChatMessage {
-  role: "user" | "assistant";
-  content: string;
-}
+export class BedrockChatProvider implements ChatProvider {
+  async *streamChat(
+    messages: ChatMessage[],
+    context: string,
+    options: ChatOptions = {}
+  ): AsyncGenerator<string> {
+    const modelId = options.modelId ?? DEFAULT_MODEL_ID;
+    const maxTokens = options.maxTokens ?? 1024;
+    const temperature = options.temperature ?? 0.7;
 
-export interface ChatOptions {
-  modelId?: string;
-  maxTokens?: number;
-  temperature?: number;
-  systemPrompt?: string;
-}
+    const systemPrompt = options.systemPrompt ??
+      `You are a helpful assistant for Eriberto Lopez's portfolio site. Answer questions based on the following context. If the context doesn't contain relevant information, say so.\n\nContext:\n${context}`;
 
-export async function* streamChat(
-  messages: ChatMessage[],
-  context: string,
-  options: ChatOptions = {}
-): AsyncGenerator<string> {
-  // TODO: Build Anthropic Messages API payload (Bedrock uses same format)
-  // TODO: Include system prompt with retrieved context
-  // TODO: Call InvokeModelWithResponseStream
-  // TODO: Parse SSE chunks and yield text deltas
-  // TODO: Handle errors (throttling, context length exceeded)
-  throw new Error("Not implemented");
+    // TODO: Build Anthropic Messages API payload
+    // {
+    //   anthropic_version: "bedrock-2023-05-31",
+    //   max_tokens: maxTokens,
+    //   temperature,
+    //   system: systemPrompt,
+    //   messages: messages.map(m => ({ role: m.role, content: m.content }))
+    // }
+
+    // TODO: Call InvokeModelWithResponseStream
+    // TODO: Parse response chunks (content_block_delta events)
+    // TODO: Yield text deltas
+    // TODO: Handle errors: ThrottlingException, ModelTimeoutException, ValidationException
+
+    throw new Error("Not implemented");
+  }
 }

--- a/lib/embeddings/bedrock.ts
+++ b/lib/embeddings/bedrock.ts
@@ -1,32 +1,49 @@
-// TODO: Phase 3 - Bedrock Titan Embeddings Provider
-// Replaces Ollama/OpenAI embeddings with Amazon Bedrock Titan.
-//
-// Model: amazon.titan-embed-text-v2:0
-// Input: text string (max 8192 tokens)
-// Output: 1024-dimension float vector
-//
-// Uses AWS SDK v3 BedrockRuntimeClient.
-// IAM role provides credentials — no API key needed.
-//
-// See docs/AWS_MIGRATION_PLAN.md "Phase 3" for details.
+// Phase 3: Bedrock Titan Embeddings Provider
+// Implements EmbeddingProvider interface for Amazon Bedrock Titan
+// Model: configurable via BEDROCK_EMBED_MODEL_ID env var
+// See docs/AWS_MIGRATION_PLAN.md "Phase 3"
 
 import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import type { EmbeddingProvider } from "../types/providers";
 
-const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+const client = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? "us-east-1",
+  // Retry config with exponential backoff
+  maxAttempts: 3,
+});
 
-const MODEL_ID = "amazon.titan-embed-text-v2:0";
+const MODEL_ID = process.env.BEDROCK_EMBED_MODEL_ID ?? "amazon.titan-embed-text-v2:0";
+const MAX_INPUT_LENGTH = 8192;
+const EMBEDDING_DIMENSIONS = 1024;
+const MAX_CONCURRENT = 5;
 
-export async function generateEmbedding(text: string): Promise<number[]> {
-  // TODO: Implement Bedrock Titan embedding call
-  // TODO: Add input validation (max length, empty string check)
-  // TODO: Add error handling (throttling, model errors)
-  // TODO: Add retry logic with exponential backoff
-  throw new Error("Not implemented");
-}
+export class BedrockEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions = EMBEDDING_DIMENSIONS;
 
-export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
-  // TODO: Batch embedding generation
-  // TODO: Titan doesn't support batch natively — parallelize with concurrency limit
-  // TODO: Add rate limiting to avoid throttling
-  throw new Error("Not implemented");
+  async generateEmbedding(text: string): Promise<number[]> {
+    if (!text || text.trim().length === 0) {
+      throw new Error("Empty text provided for embedding");
+    }
+    if (text.length > MAX_INPUT_LENGTH) {
+      throw new Error(`Text exceeds max length of ${MAX_INPUT_LENGTH} characters`);
+    }
+
+    // TODO: Invoke Bedrock Titan with text
+    // TODO: Parse response and extract embedding vector
+    // TODO: Validate embedding dimensions match expected
+    throw new Error("Not implemented");
+  }
+
+  async generateEmbeddings(texts: string[]): Promise<number[][]> {
+    // Batch with concurrency limit (Titan doesn't support native batch)
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i += MAX_CONCURRENT) {
+      const batch = texts.slice(i, i + MAX_CONCURRENT);
+      const embeddings = await Promise.all(
+        batch.map((text) => this.generateEmbedding(text))
+      );
+      results.push(...embeddings);
+    }
+    return results;
+  }
 }

--- a/lib/embeddings/bedrock.ts
+++ b/lib/embeddings/bedrock.ts
@@ -1,0 +1,32 @@
+// TODO: Phase 3 - Bedrock Titan Embeddings Provider
+// Replaces Ollama/OpenAI embeddings with Amazon Bedrock Titan.
+//
+// Model: amazon.titan-embed-text-v2:0
+// Input: text string (max 8192 tokens)
+// Output: 1024-dimension float vector
+//
+// Uses AWS SDK v3 BedrockRuntimeClient.
+// IAM role provides credentials — no API key needed.
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 3" for details.
+
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+
+const MODEL_ID = "amazon.titan-embed-text-v2:0";
+
+export async function generateEmbedding(text: string): Promise<number[]> {
+  // TODO: Implement Bedrock Titan embedding call
+  // TODO: Add input validation (max length, empty string check)
+  // TODO: Add error handling (throttling, model errors)
+  // TODO: Add retry logic with exponential backoff
+  throw new Error("Not implemented");
+}
+
+export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
+  // TODO: Batch embedding generation
+  // TODO: Titan doesn't support batch natively — parallelize with concurrency limit
+  // TODO: Add rate limiting to avoid throttling
+  throw new Error("Not implemented");
+}

--- a/lib/types/providers.ts
+++ b/lib/types/providers.ts
@@ -1,0 +1,28 @@
+// Provider interfaces for embeddings and chat
+// Enables swapping between Ollama (local dev) and Bedrock (prod)
+
+export interface EmbeddingProvider {
+  generateEmbedding(text: string): Promise<number[]>;
+  generateEmbeddings(texts: string[]): Promise<number[][]>;
+  readonly dimensions: number;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ChatOptions {
+  modelId?: string;
+  maxTokens?: number;
+  temperature?: number;
+  systemPrompt?: string;
+}
+
+export interface ChatProvider {
+  streamChat(
+    messages: ChatMessage[],
+    context: string,
+    options?: ChatOptions
+  ): AsyncGenerator<string>;
+}

--- a/localstack/init-db/01-init-pgvector.sql
+++ b/localstack/init-db/01-init-pgvector.sql
@@ -1,0 +1,22 @@
+-- Initialize pgvector extension and schema for local development
+-- Mirrors Phase 6 RDS PostgreSQL setup
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS documents (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  embedding vector(1024),  -- Titan v2 dimensions
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- HNSW index for fast cosine similarity search
+CREATE INDEX IF NOT EXISTS documents_embedding_idx
+  ON documents USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Index for metadata filtering
+CREATE INDEX IF NOT EXISTS documents_metadata_idx
+  ON documents USING gin (metadata);

--- a/localstack/init/01-setup-resources.sh
+++ b/localstack/init/01-setup-resources.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# LocalStack init script — runs when LocalStack is ready
+# Creates AWS resources that mirror production infrastructure
+
+set -euo pipefail
+
+ENDPOINT="http://localhost:4566"
+REGION="us-east-1"
+AWS="awslocal"
+
+echo "==> Creating S3 bucket (mirrors Phase 1 StaticSiteStack)..."
+$AWS s3 mb s3://eribertolopez-site --region $REGION 2>/dev/null || true
+$AWS s3api put-bucket-encryption --bucket eribertolopez-site \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+echo "==> Creating SSM parameters..."
+$AWS ssm put-parameter --name /chat-api/url --value "http://localhost:4566/restapis" --type String --overwrite
+$AWS ssm put-parameter --name /chat-api/allowed-origins --value "http://localhost:3000,http://localhost:4566" --type String --overwrite
+
+echo "==> Creating Secrets Manager secret (mirrors Phase 6 RDS credentials)..."
+$AWS secretsmanager create-secret \
+  --name portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}' \
+  2>/dev/null || \
+$AWS secretsmanager update-secret \
+  --secret-id portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}'
+
+echo "==> Creating DynamoDB table for rate limiting..."
+$AWS dynamodb create-table \
+  --table-name chat-rate-limits \
+  --attribute-definitions AttributeName=pk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region $REGION 2>/dev/null || true
+
+echo "==> Creating SQS queue for ingestion..."
+$AWS sqs create-queue --queue-name ingestion-queue --region $REGION 2>/dev/null || true
+
+echo "==> LocalStack initialization complete!"

--- a/scripts/localstack-setup.sh
+++ b/scripts/localstack-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Quick setup script for LocalStack local development
+# Usage: ./scripts/localstack-setup.sh [up|down|status|logs]
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.localstack.yml"
+ACTION="${1:-up}"
+
+case "$ACTION" in
+  up)
+    echo "🚀 Starting LocalStack + PostgreSQL..."
+    docker compose -f "$COMPOSE_FILE" up -d
+    echo ""
+    echo "⏳ Waiting for services to be healthy..."
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    echo "✅ LocalStack: http://localhost:4566/_localstack/health"
+    echo "✅ PostgreSQL: localhost:5432 (chatdev/localdev123)"
+    echo ""
+    echo "Set these environment variables:"
+    echo "  export USE_LOCALSTACK=true"
+    echo "  export AWS_DEFAULT_REGION=us-east-1"
+    echo ""
+    echo "Or add to .env.local:"
+    echo "  USE_LOCALSTACK=true"
+    ;;
+  down)
+    echo "🛑 Stopping LocalStack..."
+    docker compose -f "$COMPOSE_FILE" down
+    ;;
+  clean)
+    echo "🧹 Stopping and removing all data..."
+    docker compose -f "$COMPOSE_FILE" down -v
+    rm -rf localstack/data
+    ;;
+  status)
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    curl -s http://localhost:4566/_localstack/health | python3 -m json.tool 2>/dev/null || echo "LocalStack not running"
+    ;;
+  logs)
+    docker compose -f "$COMPOSE_FILE" logs -f "${2:-localstack}"
+    ;;
+  *)
+    echo "Usage: $0 [up|down|clean|status|logs]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Phase 3: Bedrock Integration

Implements provider stubs for Phase 3 of the [AWS Migration Plan](docs/AWS_MIGRATION_PLAN.md).

### What's included
- `lib/embeddings/bedrock.ts` — Titan embedding provider stub
- `lib/chat/bedrock.ts` — Claude chat provider stub with streaming interface

### What needs implementation
- Bedrock Titan embedding calls with retry logic
- Bedrock Claude streaming chat with proper SSE parsing
- Batch embedding with concurrency limiting
- Provider interface abstraction for local dev (Ollama) vs prod (Bedrock)

Depends on: Phase 2