### PR TITLE
Phase 6: RDS PostgreSQL + pgvector — Replace Supabase (Optional)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Rate limiting
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX_REQUESTS=10
+
+# ──────────────────────────────────────────────
+# LocalStack / AWS Local Development
+# ──────────────────────────────────────────────
+
+# Set to "true" to route AWS SDK calls to LocalStack
+# USE_LOCALSTACK=true
+# LOCALSTACK_ENDPOINT=http://localhost:4566
+# AWS_REGION=us-east-1
+
+# Local PostgreSQL (used with LocalStack instead of RDS)
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=chatdev
+# DB_PASSWORD=localdev123
+# DB_NAME=portfolio_chat

--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,5 @@ out/
 .DS_Store
 node_modules
 .env.local
+# LocalStack persistent data
+localstack/data/

--- a/docker-compose.localstack.yml
+++ b/docker-compose.localstack.yml
@@ -1,0 +1,54 @@
+# LocalStack Docker Compose for local AWS development
+# Usage: docker compose -f docker-compose.localstack.yml up -d
+# Dashboard: http://localhost:4566/_localstack/health
+#
+# Services emulated: S3, CloudFront (stubbed), Lambda, API Gateway,
+# DynamoDB, SQS, Secrets Manager, SSM, IAM, STS, Bedrock (stubbed)
+
+version: "3.8"
+
+services:
+  localstack:
+    image: localstack/localstack:3.4
+    container_name: localstack-aws-dev
+    ports:
+      - "4566:4566"           # LocalStack Gateway
+      - "4510-4559:4510-4559" # External service ports
+    environment:
+      - SERVICES=s3,lambda,apigateway,apigatewayv2,dynamodb,sqs,secretsmanager,ssm,iam,sts,cloudfront,logs
+      - DEBUG=${LOCALSTACK_DEBUG:-0}
+      - LAMBDA_EXECUTOR=docker-reuse
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_DEFAULT_REGION=us-east-1
+      - PERSISTENCE=1
+    volumes:
+      - "./localstack/init:/etc/localstack/init/ready.d"
+      - "./localstack/data:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # PostgreSQL with pgvector for local vector store (mirrors RDS Phase 6)
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: localstack-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: chatdev
+      POSTGRES_PASSWORD: localdev123
+      POSTGRES_DB: portfolio_chat
+    volumes:
+      - "./localstack/init-db:/docker-entrypoint-initdb.d"
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chatdev"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/docs/LOCAL_DEV_GUIDE.md
+++ b/docs/LOCAL_DEV_GUIDE.md
@@ -1,0 +1,94 @@
+# Local Development Guide — AWS Stack with LocalStack
+
+## Prerequisites
+
+- Docker & Docker Compose
+- Node.js 20+
+- AWS CLI v2 (optional, for `awslocal` wrapper)
+- [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/) (optional but recommended)
+
+## Quick Start
+
+```bash
+# 1. Start LocalStack + PostgreSQL
+./scripts/localstack-setup.sh up
+
+# 2. Set environment
+cp .env.example .env.local
+# Add: USE_LOCALSTACK=true
+
+# 3. Install dependencies
+npm install
+
+# 4. Run the dev server
+npm run dev
+```
+
+## Environment Variables
+
+| Variable | Local Value | Description |
+|----------|------------|-------------|
+| `USE_LOCALSTACK` | `true` | Routes AWS SDK calls to LocalStack |
+| `LOCALSTACK_ENDPOINT` | `http://localhost:4566` | LocalStack endpoint (default) |
+| `AWS_REGION` | `us-east-1` | AWS region |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_USER` | `chatdev` | PostgreSQL user |
+| `DB_PASSWORD` | `localdev123` | PostgreSQL password |
+| `DB_NAME` | `portfolio_chat` | PostgreSQL database |
+
+## What's Running
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| LocalStack | `http://localhost:4566` | S3, Lambda, API Gateway, DynamoDB, SQS, SSM, Secrets Manager |
+| PostgreSQL + pgvector | `localhost:5432` | Vector store (mirrors RDS Phase 6) |
+
+## Using AWS CLI with LocalStack
+
+```bash
+# Option 1: awslocal wrapper (if localstack CLI installed)
+awslocal s3 ls
+awslocal dynamodb list-tables
+
+# Option 2: AWS CLI with --endpoint-url
+aws --endpoint-url=http://localhost:4566 s3 ls
+```
+
+## Testing CDK Stacks Locally
+
+```bash
+cd infra
+USE_LOCALSTACK=true npx cdklocal bootstrap
+USE_LOCALSTACK=true npx cdklocal deploy --all
+```
+
+## Services Setup
+
+The init script (`localstack/init/01-setup-resources.sh`) automatically creates:
+- S3 bucket: `eribertolopez-site`
+- SSM parameters: `/chat-api/url`, `/chat-api/allowed-origins`
+- Secrets Manager: `portfolio-chat/db-credentials`
+- DynamoDB table: `chat-rate-limits`
+- SQS queue: `ingestion-queue`
+
+PostgreSQL init (`localstack/init-db/01-init-pgvector.sql`) creates:
+- `vector` extension
+- `documents` table with embedding column
+- HNSW index for similarity search
+
+## Lifecycle
+
+```bash
+./scripts/localstack-setup.sh up      # Start
+./scripts/localstack-setup.sh status   # Check health
+./scripts/localstack-setup.sh logs     # View logs
+./scripts/localstack-setup.sh down     # Stop (preserves data)
+./scripts/localstack-setup.sh clean    # Stop + delete all data
+```
+
+## Limitations
+
+- **Bedrock is not emulated** — LocalStack community edition doesn't support Bedrock. For local chat/embedding testing, use Ollama providers (already configured in `lib/embeddings/ollama.ts` and `lib/chat/ollama.ts`).
+- **CloudFront** — Stubbed only. Test S3 serving directly.
+- **Lambda** — Requires Docker-in-Docker. Works with `LAMBDA_EXECUTOR=docker-reuse`.

--- a/infra/lib/database-stack.ts
+++ b/infra/lib/database-stack.ts
@@ -1,0 +1,34 @@
+// TODO: Phase 6 - Database Stack (RDS PostgreSQL + pgvector)
+// Creates:
+// - VPC with public and private subnets (2 AZs)
+// - RDS PostgreSQL instance (db.t4g.micro, private subnet)
+// - Security groups (Lambda→RDS, ECS→RDS ingress on 5432)
+// - VPC endpoints for Bedrock and CloudWatch Logs
+// - Secrets Manager secret for DB credentials
+// - Custom resource to enable pgvector extension
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 6" for full details.
+
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export class DatabaseStack extends cdk.Stack {
+  // TODO: Export VPC, security groups, DB endpoint for other stacks
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // TODO: Create VPC (2 AZs, 1 NAT gateway to save cost)
+    // TODO: Create RDS PostgreSQL 16 instance (db.t4g.micro)
+    //   - Enable storage encryption
+    //   - Enable automated backups (7 day retention)
+    //   - Enable deletion protection
+    //   - Set max_connections appropriate for micro instance
+    // TODO: Create security groups
+    //   - Lambda SG → DB SG on port 5432
+    //   - ECS SG → DB SG on port 5432
+    // TODO: Create Secrets Manager secret for DB credentials
+    // TODO: Create VPC endpoints (Bedrock, CloudWatch, S3 gateway)
+    // TODO: Add custom resource Lambda to run CREATE EXTENSION vector
+  }
+}

--- a/infra/lib/database-stack.ts
+++ b/infra/lib/database-stack.ts
@@ -1,34 +1,68 @@
-// TODO: Phase 6 - Database Stack (RDS PostgreSQL + pgvector)
-// Creates:
-// - VPC with public and private subnets (2 AZs)
-// - RDS PostgreSQL instance (db.t4g.micro, private subnet)
-// - Security groups (Lambda→RDS, ECS→RDS ingress on 5432)
-// - VPC endpoints for Bedrock and CloudWatch Logs
-// - Secrets Manager secret for DB credentials
-// - Custom resource to enable pgvector extension
+// Phase 6: Database Stack — RDS PostgreSQL + pgvector
+// Creates VPC, RDS instance, RDS Proxy, security groups, VPC endpoints
+// See docs/AWS_MIGRATION_PLAN.md "Phase 6"
 //
-// See docs/AWS_MIGRATION_PLAN.md "Phase 6" for full details.
+// ⚠️  COST WARNING: This phase adds ~$30-50/month.
+//     Consider keeping Supabase free tier unless self-hosting is required.
 
 import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as rds from "aws-cdk-lib/aws-rds";
 import { Construct } from "constructs";
 
 export class DatabaseStack extends cdk.Stack {
-  // TODO: Export VPC, security groups, DB endpoint for other stacks
+  public readonly vpc: ec2.IVpc;
+  public readonly dbEndpoint: string;
+  public readonly lambdaSecurityGroup: ec2.ISecurityGroup;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // TODO: Create VPC (2 AZs, 1 NAT gateway to save cost)
-    // TODO: Create RDS PostgreSQL 16 instance (db.t4g.micro)
-    //   - Enable storage encryption
-    //   - Enable automated backups (7 day retention)
-    //   - Enable deletion protection
-    //   - Set max_connections appropriate for micro instance
-    // TODO: Create security groups
-    //   - Lambda SG → DB SG on port 5432
-    //   - ECS SG → DB SG on port 5432
-    // TODO: Create Secrets Manager secret for DB credentials
-    // TODO: Create VPC endpoints (Bedrock, CloudWatch, S3 gateway)
-    // TODO: Add custom resource Lambda to run CREATE EXTENSION vector
+    // VPC — 2 AZs, private subnets for RDS, VPC endpoints instead of NAT Gateway ($32/mo savings)
+    // TODO: Create VPC with:
+    //   - 2 AZs
+    //   - Private isolated subnets (for RDS)
+    //   - Private with egress subnets (for Lambda, using VPC endpoints)
+    //   - NO NAT Gateway (use VPC endpoints instead)
+
+    // Security Groups
+    // TODO: Create Lambda SG and ECS SG
+    // TODO: Create DB SG allowing inbound 5432 from Lambda SG and ECS SG only
+
+    // RDS PostgreSQL 16 Instance
+    // TODO: Create RDS instance with:
+    //   - Engine: PostgreSQL 16
+    //   - Instance: db.t4g.micro
+    //   - Storage: 20GB gp3, encrypted
+    //   - Multi-AZ: false (cost savings for portfolio site)
+    //   - Automated backups: 7-day retention
+    //   - Deletion protection: enabled
+    //   - IAM authentication: ENABLED (prefer over password auth)
+    //   - SSL enforcement: rds.force_ssl = 1 in parameter group
+    //   - Performance Insights: enabled (free tier)
+
+    // RDS Proxy — CRITICAL for Lambda connection management
+    // TODO: Create RDS Proxy with:
+    //   - Engine family: POSTGRESQL
+    //   - IAM auth: required
+    //   - Connection pooling: max 80% of db max_connections
+    //   - Idle timeout: 300 seconds
+    //   This prevents Lambda connection storms on db.t4g.micro (82 max_connections)
+
+    // VPC Endpoints — replace NAT Gateway to save $32/month
+    // TODO: Create VPC endpoints for:
+    //   - com.amazonaws.{region}.bedrock-runtime (Interface)
+    //   - com.amazonaws.{region}.secretsmanager (Interface)
+    //   - com.amazonaws.{region}.logs (Interface)
+    //   - com.amazonaws.{region}.s3 (Gateway — free)
+
+    // Custom Resource — enable pgvector extension
+    // TODO: Lambda custom resource that runs:
+    //   CREATE EXTENSION IF NOT EXISTS vector;
+
+    // Outputs
+    this.vpc = {} as ec2.IVpc; // TODO: Set from VPC construct
+    this.dbEndpoint = ""; // TODO: Set from RDS Proxy endpoint (not direct RDS)
+    this.lambdaSecurityGroup = {} as ec2.ISecurityGroup; // TODO: Set from SG
   }
 }

--- a/lib/aws-config.ts
+++ b/lib/aws-config.ts
@@ -1,0 +1,68 @@
+// AWS SDK configuration with LocalStack support
+// Set USE_LOCALSTACK=true to route all AWS calls to LocalStack
+//
+// Usage:
+//   import { getAwsConfig, getEndpoint } from "@/lib/aws-config";
+//   const client = new S3Client(getAwsConfig());
+
+export interface AwsConfig {
+  region: string;
+  endpoint?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+  forcePathStyle?: boolean; // For S3 with LocalStack
+}
+
+const LOCALSTACK_ENDPOINT =
+  process.env.LOCALSTACK_ENDPOINT ?? "http://localhost:4566";
+
+export function isLocalStack(): boolean {
+  return process.env.USE_LOCALSTACK === "true";
+}
+
+export function getEndpoint(): string | undefined {
+  return isLocalStack() ? LOCALSTACK_ENDPOINT : undefined;
+}
+
+export function getAwsConfig(): AwsConfig {
+  const config: AwsConfig = {
+    region: process.env.AWS_REGION ?? "us-east-1",
+  };
+
+  if (isLocalStack()) {
+    config.endpoint = LOCALSTACK_ENDPOINT;
+    config.credentials = {
+      accessKeyId: "test",
+      secretAccessKey: "test",
+    };
+    config.forcePathStyle = true; // Required for S3 with LocalStack
+  }
+
+  return config;
+}
+
+// Database config — uses Secrets Manager in prod, env vars with LocalStack
+export function getDbConfig() {
+  if (isLocalStack()) {
+    return {
+      host: process.env.DB_HOST ?? "localhost",
+      port: parseInt(process.env.DB_PORT ?? "5432"),
+      user: process.env.DB_USER ?? "chatdev",
+      password: process.env.DB_PASSWORD ?? "localdev123",
+      database: process.env.DB_NAME ?? "portfolio_chat",
+      ssl: false,
+    };
+  }
+
+  // Production: credentials come from Secrets Manager via RDS Proxy IAM auth
+  return {
+    host: process.env.DB_HOST!,
+    port: parseInt(process.env.DB_PORT ?? "5432"),
+    user: process.env.DB_USER!,
+    database: process.env.DB_NAME ?? "portfolio_chat",
+    ssl: { rejectUnauthorized: true },
+    // IAM auth token is generated at connection time
+  };
+}

--- a/lib/vectorStore/rds.ts
+++ b/lib/vectorStore/rds.ts
@@ -1,4 +1,4 @@
-// TODO: Phase 6 - RDS PostgreSQL + pgvector Vector Store
+// Phase 6 - RDS PostgreSQL + pgvector Vector Store
 // Replaces Supabase pgvector with self-managed RDS PostgreSQL.
 //
 // This module provides:
@@ -7,9 +7,13 @@
 // - Document upsert with embeddings
 // - Schema initialization (CREATE EXTENSION, tables)
 //
+// LocalStack: Set USE_LOCALSTACK=true to connect to local PostgreSQL
+// instead of RDS. See lib/aws-config.ts for connection details.
+//
 // See docs/AWS_MIGRATION_PLAN.md "Phase 6" for details.
 
 // import { Pool } from "pg";
+import { getDbConfig, isLocalStack } from "../aws-config";
 
 export interface DocumentChunk {
   id: string;
@@ -26,6 +30,11 @@ export interface SearchResult {
 }
 
 export class RdsVectorStore {
+  // Connection config comes from lib/aws-config.ts:
+  // - LocalStack mode: uses env vars (DB_HOST, DB_USER, etc.)
+  // - Production: uses Secrets Manager credentials via RDS Proxy + IAM auth
+  private readonly config = getDbConfig();
+
   // TODO: Initialize connection pool from Secrets Manager credentials
   // TODO: Use IAM database authentication as alternative
 

--- a/lib/vectorStore/rds.ts
+++ b/lib/vectorStore/rds.ts
@@ -1,0 +1,56 @@
+// TODO: Phase 6 - RDS PostgreSQL + pgvector Vector Store
+// Replaces Supabase pgvector with self-managed RDS PostgreSQL.
+//
+// This module provides:
+// - Connection pooling via pg Pool
+// - Vector similarity search (cosine distance)
+// - Document upsert with embeddings
+// - Schema initialization (CREATE EXTENSION, tables)
+//
+// See docs/AWS_MIGRATION_PLAN.md "Phase 6" for details.
+
+// import { Pool } from "pg";
+
+export interface DocumentChunk {
+  id: string;
+  content: string;
+  embedding: number[];
+  metadata: Record<string, unknown>;
+}
+
+export interface SearchResult {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  similarity: number;
+}
+
+export class RdsVectorStore {
+  // TODO: Initialize connection pool from Secrets Manager credentials
+  // TODO: Use IAM database authentication as alternative
+
+  async initialize(): Promise<void> {
+    // TODO: CREATE EXTENSION IF NOT EXISTS vector;
+    // TODO: Create documents table with vector column
+    // TODO: Create HNSW or IVFFlat index for fast search
+    throw new Error("Not implemented");
+  }
+
+  async upsert(chunks: DocumentChunk[]): Promise<void> {
+    // TODO: Batch INSERT ... ON CONFLICT UPDATE
+    // TODO: Use parameterized queries to prevent SQL injection
+    // TODO: Add transaction wrapping for atomicity
+    throw new Error("Not implemented");
+  }
+
+  async search(embedding: number[], topK: number = 5): Promise<SearchResult[]> {
+    // TODO: SELECT with cosine distance operator (<=>)
+    // TODO: Filter by similarity threshold
+    // TODO: Return content + metadata + similarity score
+    throw new Error("Not implemented");
+  }
+
+  async close(): Promise<void> {
+    // TODO: Drain connection pool
+  }
+}

--- a/localstack/init-db/01-init-pgvector.sql
+++ b/localstack/init-db/01-init-pgvector.sql
@@ -1,0 +1,22 @@
+-- Initialize pgvector extension and schema for local development
+-- Mirrors Phase 6 RDS PostgreSQL setup
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS documents (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  embedding vector(1024),  -- Titan v2 dimensions
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- HNSW index for fast cosine similarity search
+CREATE INDEX IF NOT EXISTS documents_embedding_idx
+  ON documents USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Index for metadata filtering
+CREATE INDEX IF NOT EXISTS documents_metadata_idx
+  ON documents USING gin (metadata);

--- a/localstack/init/01-setup-resources.sh
+++ b/localstack/init/01-setup-resources.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# LocalStack init script — runs when LocalStack is ready
+# Creates AWS resources that mirror production infrastructure
+
+set -euo pipefail
+
+ENDPOINT="http://localhost:4566"
+REGION="us-east-1"
+AWS="awslocal"
+
+echo "==> Creating S3 bucket (mirrors Phase 1 StaticSiteStack)..."
+$AWS s3 mb s3://eribertolopez-site --region $REGION 2>/dev/null || true
+$AWS s3api put-bucket-encryption --bucket eribertolopez-site \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+echo "==> Creating SSM parameters..."
+$AWS ssm put-parameter --name /chat-api/url --value "http://localhost:4566/restapis" --type String --overwrite
+$AWS ssm put-parameter --name /chat-api/allowed-origins --value "http://localhost:3000,http://localhost:4566" --type String --overwrite
+
+echo "==> Creating Secrets Manager secret (mirrors Phase 6 RDS credentials)..."
+$AWS secretsmanager create-secret \
+  --name portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}' \
+  2>/dev/null || \
+$AWS secretsmanager update-secret \
+  --secret-id portfolio-chat/db-credentials \
+  --secret-string '{"username":"chatdev","password":"localdev123","host":"postgres","port":"5432","dbname":"portfolio_chat"}'
+
+echo "==> Creating DynamoDB table for rate limiting..."
+$AWS dynamodb create-table \
+  --table-name chat-rate-limits \
+  --attribute-definitions AttributeName=pk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region $REGION 2>/dev/null || true
+
+echo "==> Creating SQS queue for ingestion..."
+$AWS sqs create-queue --queue-name ingestion-queue --region $REGION 2>/dev/null || true
+
+echo "==> LocalStack initialization complete!"

--- a/scripts/localstack-setup.sh
+++ b/scripts/localstack-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Quick setup script for LocalStack local development
+# Usage: ./scripts/localstack-setup.sh [up|down|status|logs]
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.localstack.yml"
+ACTION="${1:-up}"
+
+case "$ACTION" in
+  up)
+    echo "🚀 Starting LocalStack + PostgreSQL..."
+    docker compose -f "$COMPOSE_FILE" up -d
+    echo ""
+    echo "⏳ Waiting for services to be healthy..."
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    echo "✅ LocalStack: http://localhost:4566/_localstack/health"
+    echo "✅ PostgreSQL: localhost:5432 (chatdev/localdev123)"
+    echo ""
+    echo "Set these environment variables:"
+    echo "  export USE_LOCALSTACK=true"
+    echo "  export AWS_DEFAULT_REGION=us-east-1"
+    echo ""
+    echo "Or add to .env.local:"
+    echo "  USE_LOCALSTACK=true"
+    ;;
+  down)
+    echo "🛑 Stopping LocalStack..."
+    docker compose -f "$COMPOSE_FILE" down
+    ;;
+  clean)
+    echo "🧹 Stopping and removing all data..."
+    docker compose -f "$COMPOSE_FILE" down -v
+    rm -rf localstack/data
+    ;;
+  status)
+    docker compose -f "$COMPOSE_FILE" ps
+    echo ""
+    curl -s http://localhost:4566/_localstack/health | python3 -m json.tool 2>/dev/null || echo "LocalStack not running"
+    ;;
+  logs)
+    docker compose -f "$COMPOSE_FILE" logs -f "${2:-localstack}"
+    ;;
+  *)
+    echo "Usage: $0 [up|down|clean|status|logs]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Phase 6: RDS PostgreSQL + pgvector (Optional)

Implements stubs for Phase 6 of the [AWS Migration Plan](docs/AWS_MIGRATION_PLAN.md).

### What's included
- `lib/vectorStore/rds.ts` — RDS pgvector store with search/upsert interface
- `infra/lib/database-stack.ts` — CDK stack for VPC + RDS + security groups

### What needs implementation
- VPC with private subnets
- RDS PostgreSQL instance with pgvector extension
- Connection pooling and IAM auth
- Security groups for Lambda/ECS access
- Secrets Manager integration
- HNSW index for vector search

Depends on: Phase 5